### PR TITLE
Add RequestHeaderVoter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 vendor/
 composer.lock
 phpunit.xml
+/.idea

--- a/README.md
+++ b/README.md
@@ -167,6 +167,33 @@ ecn_feature_toggle:
             params: { schedule: '2015-10-23' }
 ```
 
+
+### RequestHeaderVoter
+
+This voter passes, when *all* of the specified request headers and their corresponding values are found and are equal 
+to the headers in the current request.
+
+Note, the conditions are checked if they are *equal* (==) and *not* that they are *identical* (===).
+This is because non-strings for header values in request headers are not allowed. 
+
+The name of the request header itself is by design case-insensitive.
+
+The value of the request header is case-sensitive.   
+
+If you want to use this voter, this is the full configuration:
+
+
+``` yaml
+ecn_feature_toggle:
+    features:
+        FooRequestFeature:
+            voter: RequestHeaderVoter
+            params: { headers: { Upgrade-Insecure-Requests: 1, x-cdn: 'akamai', x-location: 'cn' } }
+```
+
+In this case, all three headers must exist among the request headers and their corresponding values must be equal to that of the request headers' values.
+
+
 ## Overriding the default voter
 
 You can override the default voter like this:

--- a/README.md
+++ b/README.md
@@ -170,17 +170,21 @@ ecn_feature_toggle:
 
 ### RequestHeaderVoter
 
-This voter passes, when *all* of the specified request headers and their corresponding values are found and are equal 
-to the headers in the current request.
-
-Note, the conditions are checked if they are *equal* (==) and *not* that they are *identical* (===).
-This is because non-strings for header values in request headers are not allowed. 
-
 The name of the request header itself is by design case-insensitive.
 
-The value of the request header is case-sensitive.   
+Request header values are always treated as strings, so equal (==) checks are used and *not* identical matching (===).
 
-If you want to use this voter, this is the full configuration:
+Request header keys are by design case-insensitive.
+
+The Voter does *not* pass if the request stack contains no current requests.
+
+
+#### a. Specify key/value pairs
+
+This voter passes, when *all* of the specified headers and their corresponding values are found and *equal* 
+to that of the current request headers.
+
+Example for key/value config:
 
 
 ``` yaml
@@ -188,10 +192,32 @@ ecn_feature_toggle:
     features:
         FooRequestFeature:
             voter: RequestHeaderVoter
-            params: { headers: { Upgrade-Insecure-Requests: 1, x-cdn: 'akamai', x-location: 'cn' } }
+            params: { headers: { foo: bar, x-cdn: 'akamai', x-location: 'cn' } }
 ```
 
-In this case, all three headers must exist among the request headers and their corresponding values must be equal to that of the request headers' values.
+
+#### b. specify request header keys only
+
+You can also specify a list of request header keys without values.
+
+In this case, only the existence of *all* of the specified request headers is checked.
+
+All request header names are by the standard case-insensitive.
+
+
+Example:
+
+``` yaml
+ecn_feature_toggle:
+    features:
+        FooRequestFeature:
+            voter: RequestHeaderVoter
+            params: { headers: { x-mobile, x-foo-debug-header } }
+```
+
+
+Mixing the two configurations is discouraged as it will lead to unexpected results by treating the config as key/value pairs, 
+and will most likely cause the Voter to *not* pass.
 
 
 ## Overriding the default voter

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,6 +11,7 @@
         <parameter key="ecn_featuretoggle.voter_alwaysfalse.class">Ecn\FeatureToggleBundle\Voters\AlwaysFalseVoter</parameter>
         <parameter key="ecn_featuretoggle.voter_ratio.class">Ecn\FeatureToggleBundle\Voters\RatioVoter</parameter>
         <parameter key="ecn_featuretoggle.voter_schedule.class">Ecn\FeatureToggleBundle\Voters\ScheduleVoter</parameter>
+        <parameter key="ecn_featuretoggle.voter_request_header.class">Ecn\FeatureToggleBundle\Voters\RequestHeaderVoter</parameter>
         <parameter key="ecn_featuretoggle.twig.class">Ecn\FeatureToggleBundle\Twig\FeatureToggleExtension</parameter>
         <parameter key="ecn_featuretoggle.controller_listener.class">Ecn\FeatureToggleBundle\EventListener\ControllerListener</parameter>
     </parameters>
@@ -48,6 +49,14 @@
         <!-- Schedule Voter -->
         <service id="ecn_featuretoggle.voter_schedule" class="%ecn_featuretoggle.voter_schedule.class%">
             <tag name="ecn_featuretoggle.voter" alias="ScheduleVoter"/>
+        </service>
+
+        <!-- Request Header Voter -->
+        <service id="ecn_featuretoggle.voter_request_header" class="%ecn_featuretoggle.voter_request_header.class%">
+            <call method="setRequest">
+                <argument id="request_stack" type="service"/>
+            </call>
+            <tag name="ecn_featuretoggle.voter" alias="RequestHeaderVoter"/>
         </service>
 
         <!-- Twig extension for feature toggle -->

--- a/Tests/Voters/RequestHeaderVoterTest.php
+++ b/Tests/Voters/RequestHeaderVoterTest.php
@@ -16,11 +16,19 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * @group request-header
  * @author Andras Debreczeni <dev@debreczeniandras.hu>
  */
 class RequestHeaderVoterTest extends \PHPUnit_Framework_TestCase
 {
+    public function testIsArrayAssociative()
+    {
+        $this->assertTrue(RequestHeaderVoter::isAssociativeArray(['X-cdn' => 1, ['X-Location' => 'CN']]));
+    }
+    
+    public function testIsArrayNotAssociative()
+    {
+        $this->assertFalse(RequestHeaderVoter::isAssociativeArray(['X-cdn', 'X-Location']));
+    }
     
     public function testNoCurrentRequestInRequestStack()
     {
@@ -36,7 +44,7 @@ class RequestHeaderVoterTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($voter->pass());
     }
     
-    public function testEqualOneRequestHeader()
+    public function testEqualOneRequestHeaderWithValue()
     {
         $requestHeaders = ['x-location' => 'CN'];
         $headerConfig = $requestHeaders;
@@ -46,7 +54,48 @@ class RequestHeaderVoterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($voter->pass());
     }
     
-    public function testNotEqualOneRequestHeader()
+    public function testOneRequestHeaderExists()
+    {
+        $requestHeaders = ['x-location' => '1'];
+        $headerConfig = ['x-location'];
+        
+        $voter = $this->getRequestHeaderVoter($this->getFakeRequestStack($requestHeaders), $headerConfig);
+        
+        $this->assertTrue($voter->pass());
+    }
+    
+    public function testOneRequestHeaderCaseInsensitive()
+    {
+        $requestHeaders = ['X-Location' => '1'];
+        $headerConfig = ['x-location'];
+        
+        $voter = $this->getRequestHeaderVoter($this->getFakeRequestStack($requestHeaders), $headerConfig);
+        
+        $this->assertTrue($voter->pass());
+    }
+    
+    public function testTwoRequestHeadersBothExists()
+    {
+        $requestHeaders = ['x-location' => 'CN', 'x-cdn' => 'Akamai'];
+        $headerConfig = ['x-location', 'x-cdn'];
+        
+        $voter = $this->getRequestHeaderVoter($this->getFakeRequestStack($requestHeaders), $headerConfig);
+        
+        $this->assertTrue($voter->pass());
+    }
+    
+    public function testTwoRequestHeadersOneDoesNotExist()
+    {
+        $requestHeaders = ['x-location' => 'CN'];
+        $headerConfig = ['x-location', 'x-cdn'];
+        
+        $voter = $this->getRequestHeaderVoter($this->getFakeRequestStack($requestHeaders), $headerConfig);
+        
+        $this->assertFalse($voter->pass());
+    }
+    
+    
+    public function testNotEqualOneRequestHeaderWithValue()
     {
         $requestHeaders = ['x-location' => 'CN'];
         $headerConfig = ['x-location' => 'cn'];
@@ -56,7 +105,7 @@ class RequestHeaderVoterTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($voter->pass());
     }
     
-    public function testEqualRequestNameCaseInsensitivity()
+    public function testEqualRequestNameCaseInsensitivityWithValue()
     {
         $requestHeaders = ['x-location' => 'CN'];
         $headerConfig = ['X-Location' => 'CN'];
@@ -66,7 +115,7 @@ class RequestHeaderVoterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($voter->pass());
     }
     
-    public function testEqualTwoRequestsHeader()
+    public function testEqualTwoRequestsHeaderWithValue()
     {
         $requestHeaders = ['x-location' => 'CN', 'x-cdn' => 'Akamai'];
         $headerConfig = $requestHeaders;
@@ -76,7 +125,7 @@ class RequestHeaderVoterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($voter->pass());
     }
     
-    public function testAtLeastOneNonEqualTwoRequestsHeader()
+    public function testAtLeastOneNonEqualTwoRequestsHeaderWithValue()
     {
         $requestHeaders = ['x-location' => 'CN', 'x-cdn' => 'Akamai'];
         $headerConfig = ['x-location' => 'cn', 'x-cdn' => 'Akamai'];

--- a/Tests/Voters/RequestHeaderVoterTest.php
+++ b/Tests/Voters/RequestHeaderVoterTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the ECNFeatureToggle package.
+ *
+ * (c) Pierre Groth <pierre@elbcoast.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ecn\FeatureToggleBundle\Tests\Voters;
+
+use Ecn\FeatureToggleBundle\Voters\RequestHeaderVoter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @group request-header
+ * @author Andras Debreczeni <dev@debreczeniandras.hu>
+ */
+class RequestHeaderVoterTest extends \PHPUnit_Framework_TestCase
+{
+    
+    public function testNoCurrentRequestInRequestStack()
+    {
+        $voter = $this->getRequestHeaderVoterWithoutCurrentRequest(new RequestStack(), null);
+        
+        $this->assertFalse($voter->pass());
+    }
+    
+    public function testNoRequestHeadersProvided()
+    {
+        $voter = $this->getRequestHeaderVoter($this->getFakeRequestStack(), null);
+        
+        $this->assertFalse($voter->pass());
+    }
+    
+    public function testEqualOneRequestHeader()
+    {
+        $requestHeaders = ['x-location' => 'CN'];
+        $headerConfig = $requestHeaders;
+        
+        $voter = $this->getRequestHeaderVoter($this->getFakeRequestStack($requestHeaders), $headerConfig);
+        
+        $this->assertTrue($voter->pass());
+    }
+    
+    public function testNotEqualOneRequestHeader()
+    {
+        $requestHeaders = ['x-location' => 'CN'];
+        $headerConfig = ['x-location' => 'cn'];
+    
+        $voter = $this->getRequestHeaderVoter($this->getFakeRequestStack($requestHeaders), $headerConfig);
+        
+        $this->assertFalse($voter->pass());
+    }
+    
+    public function testEqualRequestNameCaseInsensitivity()
+    {
+        $requestHeaders = ['x-location' => 'CN'];
+        $headerConfig = ['X-Location' => 'CN'];
+    
+        $voter = $this->getRequestHeaderVoter($this->getFakeRequestStack($requestHeaders), $headerConfig);
+        
+        $this->assertTrue($voter->pass());
+    }
+    
+    public function testEqualTwoRequestsHeader()
+    {
+        $requestHeaders = ['x-location' => 'CN', 'x-cdn' => 'Akamai'];
+        $headerConfig = $requestHeaders;
+        
+        $voter = $this->getRequestHeaderVoter($this->getFakeRequestStack($requestHeaders), $headerConfig);
+        
+        $this->assertTrue($voter->pass());
+    }
+    
+    public function testAtLeastOneNonEqualTwoRequestsHeader()
+    {
+        $requestHeaders = ['x-location' => 'CN', 'x-cdn' => 'Akamai'];
+        $headerConfig = ['x-location' => 'cn', 'x-cdn' => 'Akamai'];
+        
+        $voter = $this->getRequestHeaderVoter($this->getFakeRequestStack($requestHeaders), $headerConfig);
+        
+        $this->assertFalse($voter->pass());
+    }
+    
+    private function getRequestHeaderVoter(RequestStack $requestStack, $requestHeaders = null)
+    {
+        $voter = new RequestHeaderVoter();
+        $voter->setRequest($requestStack);
+        $voter->setParams(['headers' => $requestHeaders]);
+        
+        return $voter;
+    }
+    
+    private function getFakeRequestStack($headers = [])
+    {
+        // you can overwrite any value you want through the constructor if you need more control
+        $fakeRequest = Request::create('/', 'GET');
+        $fakeRequest->headers->add($headers);
+    
+        $requestStack = new RequestStack();
+        $requestStack->push($fakeRequest);
+        
+        return $requestStack;
+    }
+    
+    private function getRequestHeaderVoterWithoutCurrentRequest(RequestStack $requestStack, $requestHeaders = [])
+    {
+        $voter = new RequestHeaderVoter();
+        
+        $voter->setRequest($requestStack);
+        $voter->setParams(['headers' => $requestHeaders]);
+        
+        return $voter;
+    }
+}

--- a/Tests/Voters/RequestHeaderVoterTest.php
+++ b/Tests/Voters/RequestHeaderVoterTest.php
@@ -32,7 +32,7 @@ class RequestHeaderVoterTest extends \PHPUnit_Framework_TestCase
     
     public function testNoCurrentRequestInRequestStack()
     {
-        $voter = $this->getRequestHeaderVoterWithoutCurrentRequest(new RequestStack(), null);
+        $voter = $this->getRequestHeaderVoter(new RequestStack(), null);
         
         $this->assertFalse($voter->pass());
     }
@@ -146,7 +146,6 @@ class RequestHeaderVoterTest extends \PHPUnit_Framework_TestCase
     
     private function getFakeRequestStack($headers = [])
     {
-        // you can overwrite any value you want through the constructor if you need more control
         $fakeRequest = Request::create('/', 'GET');
         $fakeRequest->headers->add($headers);
     
@@ -154,15 +153,5 @@ class RequestHeaderVoterTest extends \PHPUnit_Framework_TestCase
         $requestStack->push($fakeRequest);
         
         return $requestStack;
-    }
-    
-    private function getRequestHeaderVoterWithoutCurrentRequest(RequestStack $requestStack, $requestHeaders = [])
-    {
-        $voter = new RequestHeaderVoter();
-        
-        $voter->setRequest($requestStack);
-        $voter->setParams(['headers' => $requestHeaders]);
-        
-        return $voter;
     }
 }

--- a/Voters/RequestHeaderVoter.php
+++ b/Voters/RequestHeaderVoter.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the ECNFeatureToggle package.
+ *
+ * (c) Pierre Groth <pierre@elbcoast.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ecn\FeatureToggleBundle\Voters;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @author    Andras Debreczeni <dev@debreczeniandras.hu>
+ */
+final class RequestHeaderVoter implements VoterInterface
+{
+    use VoterTrait;
+    
+    /** @var array */
+    private $headers = [];
+    
+    /** @var Request|null */
+    private $request;
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function setParams(array $params)
+    {
+        $this->headers = array_key_exists('headers', $params) ? $params['headers'] : null;
+    }
+    
+    /**
+     * @param RequestStack $requestStack
+     */
+    public function setRequest(RequestStack $requestStack)
+    {
+        $this->request = $requestStack->getCurrentRequest();
+    }
+    
+    /**
+     * This voter passes if ALL request headers provided match to their values.
+     */
+    public function pass()
+    {
+        if (!$this->headers) {
+            return false;
+        }
+        
+        if (!$this->request) {
+            return false;
+        }
+        
+        foreach ($this->headers as $headerKey => $headerValue) {
+            if (!$this->request->headers->has($headerKey)) {
+                return false;
+            }
+            
+            if ($this->request->headers->get($headerKey) != $headerValue) {
+                return false;
+            }
+        }
+        
+        return true;
+    }
+}


### PR DESCRIPTION
A new Voter is proposed here that allows users to define features based on request headers.
This is especially useful for request headers set by CDNs or proxys used for various purposes.
