### PR TITLE
Update to Symfony 6 and PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,5 @@ build/
 vendor/
 composer.lock
 phpunit.xml
-/.idea
 /ECNFeatureToggleBundle.iml
-/.idea/
 /.phpunit.result.cache

--- a/Attributes/Feature.php
+++ b/Attributes/Feature.php
@@ -10,26 +10,24 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Ecn\FeatureToggleBundle\Configuration;
+namespace Ecn\FeatureToggleBundle\Attributes;
 
-use Doctrine\Common\Annotations\Annotation\Required;
-use Doctrine\Common\Annotations\Annotation\Target;
+use Attribute;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
- *
- * @Annotation()
- *
- * @Target({"CLASS", "METHOD"})
  */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
 class Feature
 {
     /**
      * Feature name to be checked.
      *
-     * @var string
-     *
-     * @Required()
+     * @param string $name
      */
-    public $name = "";
+    #[Required]
+    public function __construct(public string $name = "")
+    {
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 # Change Log
 
 
+## 3.0.0 - 2022-02-01
+
+### Added
+
+- added support for PHP 8 and 8.1
+- added support for Symfony 5.4 and 6
+- added use of attributes
+
+### Changed
+
+- ControllerFilterEvent to ControllerEvent
+
+### Removed
+
+- removed support for PHP 7 and lower
+- removed support for Symfony 3 and 4
+- removed annotations
+
 ## 2.0.0 - 2019-12-25
 
 ### Added

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Ecn\FeatureToggleBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -26,24 +27,18 @@ class Configuration implements ConfigurationInterface
 {
     /**
      * {@inheritdoc}
-     *
-     * @psalm-suppress PossiblyNullReference
-     * @psalm-suppress PossiblyUndefinedMethod
-     * @psalm-suppress RedundantCondition
-     * @psalm-suppress UndefinedMethod
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('ecn_feature_toggle');
 
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            /** @psalm-suppress UndefinedMethod */
-            /** @psalm-suppress DeprecatedMethod */
-            $rootNode = $treeBuilder->root('ecn_feature_toggle');
-        }
+        /** @var ArrayNodeDefinition $rootNode */
+        $rootNode = $treeBuilder->getRootNode();
 
+        /**
+         * @psalm-suppress PossiblyNullReference
+         * @psalm-suppress PossiblyUndefinedMethod
+         */
         $rootNode
             ->children()
                 ->arrayNode('default')

--- a/DependencyInjection/EcnFeatureToggleExtension.php
+++ b/DependencyInjection/EcnFeatureToggleExtension.php
@@ -12,10 +12,11 @@ declare(strict_types=1);
 
 namespace Ecn\FeatureToggleBundle\DependencyInjection;
 
+use Exception;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 /**
  * This is the class that loads and manages your bundle configuration
@@ -30,20 +31,20 @@ class EcnFeatureToggleExtension extends Extension
      * @param array            $configs
      * @param ContainerBuilder $container
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $features = array_key_exists('features', $config) ? $config['features'] : [];
-        $default = array_key_exists('default', $config) ? $config['default'] : [];
+        $features = $config['features'] ?? [];
+        $default = $config['default'] ?? [];
 
         $container->setParameter('features', $features);
         $container->setParameter('default', $default);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
     }
 }

--- a/Exception/VoterNotFoundException.php
+++ b/Exception/VoterNotFoundException.php
@@ -12,9 +12,11 @@ declare(strict_types=1);
 
 namespace Ecn\FeatureToggleBundle\Exception;
 
+use RuntimeException;
+
 /**
  * @author Pierre Groth <pierre@elbcoast.net>
  */
-class VoterNotFoundException extends \RuntimeException
+class VoterNotFoundException extends RuntimeException
 {
 }

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 In order to install ECNFeatureToggleBundle, you need at least
 
-- PHP 7.2 or greater
-- Symfony 3.4, Symfony 4.2 or greater
+- PHP 8.0 or greater
+- Symfony 5.4 or greater
 
 ## Installation
 
@@ -19,6 +19,11 @@ In order to install ECNFeatureToggleBundle, you need at least
 
 ```bash
 $ composer require ecn/featuretoggle-bundle
+```
+
+Functionality of twig is only optional. Require it to your composer if you need it to use it.
+```bash
+$ composer require twig/twig
 ```
 
 
@@ -105,12 +110,12 @@ if ($this->get('feature')->has('MyNewFeature')) {
 
 ## Voters
 
-In order to decide if a feature is available or not, voters are being used. Currently there are five voters included.
+In order to decide if a feature is available or not, voters are being used. Currently, there are five voters included.
 
 
 ### AlwaysTrueVoter
 
-This is the default voter and it will always pass. So if you have a feature defined, it will always be displayed.
+This is the default voter, and it will always pass. So if you have a feature defined, it will always be displayed.
 
 The full configuration for using this voter looks like this:
 
@@ -143,7 +148,7 @@ This voter passes on a given ratio between 0 and 1, which makes it suitable for 
 The higher the ratio, the more likely the voter will pass. A value of 1 will make it pass every time, 0 will make it
 never pass.
 
-Additionally, the result of the first check can be bound to the users session. This is useful if you need a feature
+Additionally, the result of the first check can be bound to the users' session. This is useful if you need a feature
 to be persistent across multiple requests. To enable this, just set `sticky` to `true`.
 
 If you want to use this voter, this is the full configuration:

--- a/Service/FeatureService.php
+++ b/Service/FeatureService.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Ecn\FeatureToggleBundle\Service;
 
-use Ecn\FeatureToggleBundle\Exception\VoterNotFoundException;
 use Ecn\FeatureToggleBundle\Voters\VoterInterface;
 use Ecn\FeatureToggleBundle\Voters\VoterRegistry;
 
@@ -23,20 +22,11 @@ class FeatureService
 {
     /**
      * Contains the defined features
-     *
-     * @var array
      */
-    protected $features;
+    protected array $features;
 
-    /**
-     * @var array
-     */
-    protected $defaultVoter;
-
-    /**
-     * @var VoterRegistry
-     */
-    protected $voterRegistry;
+    protected array $defaultVoter;
+    protected VoterRegistry $voterRegistry;
 
     /**
      * FeatureService constructor
@@ -58,22 +48,14 @@ class FeatureService
      * @param string $feature
      *
      * @return bool
-     *
-     * @throws VoterNotFoundException
      */
     public function has(string $feature): bool
     {
-        if (!array_key_exists($feature, $this->features)) {
+        if (!isset($this->features[$feature])) {
             return false;
         }
 
-        try {
-            $voter = $this->initVoter($feature);
-
-            return $voter->pass();
-        } catch (VoterNotFoundException $exception) {
-            throw $exception;
-        }
+        return $this->initVoter($feature)->pass();
     }
 
     /**

--- a/Tests/EcnFeatureToggleBundleTest.php
+++ b/Tests/EcnFeatureToggleBundleTest.php
@@ -23,10 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class EcnFeatureToggleBundleTest extends TestCase
 {
-    /**
-     * @var ContainerBuilder
-     */
-    private $configuration;
+    private ContainerBuilder $configuration;
 
     /**
      * Test if the default configuration for a feature
@@ -37,7 +34,7 @@ class EcnFeatureToggleBundleTest extends TestCase
     public function testDefaultSettings(): void
     {
         $this->createConfiguration([
-            'features' => ['testfeature' => []]
+            'features' => ['testFeature' => []]
         ]);
 
         // Load feature config
@@ -45,15 +42,13 @@ class EcnFeatureToggleBundleTest extends TestCase
         $default = $this->configuration->getParameter('default');
 
         $this->assertEquals(['voter' => 'AlwaysTrueVoter', 'params' => []], $default);
-        $this->assertEquals([], $features['testfeature']['params']);
+        $this->assertEquals([], $features['testFeature']['params']);
     }
 
     /**
-     * @param array $config
-     *
      * @throws Exception
      */
-    private function createConfiguration($config = []): void
+    private function createConfiguration(array $config = []): void
     {
         $this->configuration = new ContainerBuilder();
 

--- a/Tests/EventListener/Fixture/FooControllerFeatureAtClass.php
+++ b/Tests/EventListener/Fixture/FooControllerFeatureAtClass.php
@@ -2,11 +2,9 @@
 
 namespace Ecn\FeatureToggleBundle\Tests\EventListener\Fixture;
 
-use Ecn\FeatureToggleBundle\Configuration\Feature;
+use Ecn\FeatureToggleBundle\Attributes\Feature;
 
-/**
- * @Feature("feature")
- */
+#[Feature(name: 'feature')]
 class FooControllerFeatureAtClass
 {
     public function barAction()

--- a/Tests/EventListener/Fixture/FooControllerFeatureAtClassAndMethod.php
+++ b/Tests/EventListener/Fixture/FooControllerFeatureAtClassAndMethod.php
@@ -2,16 +2,12 @@
 
 namespace Ecn\FeatureToggleBundle\Tests\EventListener\Fixture;
 
-use Ecn\FeatureToggleBundle\Configuration\Feature;
+use Ecn\FeatureToggleBundle\Attributes\Feature;
 
-/**
- * @Feature("feature")
- */
+#[Feature(name: 'feature')]
 class FooControllerFeatureAtClassAndMethod
 {
-    /**
-     * @Feature("feature")
-     */
+    #[Feature(name: 'feature')]
     public function barAction()
     {
     }

--- a/Tests/EventListener/Fixture/FooControllerFeatureAtInvoke.php
+++ b/Tests/EventListener/Fixture/FooControllerFeatureAtInvoke.php
@@ -2,14 +2,11 @@
 
 namespace Ecn\FeatureToggleBundle\Tests\EventListener\Fixture;
 
-use Ecn\FeatureToggleBundle\Configuration\Feature;
-
+use Ecn\FeatureToggleBundle\Attributes\Feature;
 
 class FooControllerFeatureAtInvoke
 {
-    /**
-     * @Feature("feature")
-     */
+    #[Feature(name: 'feature')]
     public function __invoke()
     {
     }

--- a/Tests/EventListener/Fixture/FooControllerFeatureAtMethod.php
+++ b/Tests/EventListener/Fixture/FooControllerFeatureAtMethod.php
@@ -2,13 +2,11 @@
 
 namespace Ecn\FeatureToggleBundle\Tests\EventListener\Fixture;
 
-use Ecn\FeatureToggleBundle\Configuration\Feature;
+use Ecn\FeatureToggleBundle\Attributes\Feature;
 
 class FooControllerFeatureAtMethod
 {
-    /**
-     * @Feature("feature")
-     */
+    #[Feature(name: 'feature')]
     public function barAction()
     {
     }

--- a/Tests/EventListener/Fixture/FooControllerFeatureAtStaticMethod.php
+++ b/Tests/EventListener/Fixture/FooControllerFeatureAtStaticMethod.php
@@ -2,13 +2,11 @@
 
 namespace Ecn\FeatureToggleBundle\Tests\EventListener\Fixture;
 
-use Ecn\FeatureToggleBundle\Configuration\Feature;
+use Ecn\FeatureToggleBundle\Attributes\Feature;
 
 class FooControllerFeatureAtStaticMethod
 {
-    /**
-     * @Feature("feature")
-     */
+    #[Feature(name: 'feature')]
     public static function barAction()
     {
     }

--- a/Tests/EventListener/Fixture/__CG__/Ecn/FeatureToggleBundle/Tests/EventListener/Fixture/FooControllerFeatureAtClass.php
+++ b/Tests/EventListener/Fixture/__CG__/Ecn/FeatureToggleBundle/Tests/EventListener/Fixture/FooControllerFeatureAtClass.php
@@ -2,8 +2,6 @@
 
 namespace Ecn\FeatureToggleBundle\Tests\EventListener\Fixture\__CG__\Ecn\FeatureToggleBundle\Tests\EventListener\Fixture;
 
-use Ecn\FeatureToggleBundle\Configuration\Feature;
-
 class FooControllerFeatureAtClass extends \Ecn\FeatureToggleBundle\Tests\EventListener\Fixture\FooControllerFeatureAtClass
 {
 }

--- a/Tests/Service/FeatureServiceTest.php
+++ b/Tests/Service/FeatureServiceTest.php
@@ -30,7 +30,7 @@ class FeatureServiceTest extends TestCase
     {
         // Define a feature
         $features = [
-            'testfeature' => [
+            'testFeature' => [
                 'voter' => 'AlwaysTrueVoter',
                 'params' => []
             ]
@@ -43,8 +43,8 @@ class FeatureServiceTest extends TestCase
         // Create service
         $service = new FeatureService($features, $default, $this->getRegistry());
 
-        $this->assertTrue($service->has('testfeature'));
-        $this->assertFalse($service->has('unknownfeature'));
+        $this->assertTrue($service->has('testFeature'));
+        $this->assertFalse($service->has('unknownFeature'));
     }
 
     /**
@@ -54,7 +54,7 @@ class FeatureServiceTest extends TestCase
     {
         // Define a feature
         $features = [
-            'testfeature' => [
+            'testFeature' => [
                 'voter' => null,
                 'params' => []
             ]
@@ -67,21 +67,21 @@ class FeatureServiceTest extends TestCase
         // Create service
         $service = new FeatureService($features, $default, $this->getRegistry());
 
-        $this->assertTrue($service->has('testfeature'));
-        $this->assertFalse($service->has('unknownfeature'));
+        $this->assertTrue($service->has('testFeature'));
+        $this->assertFalse($service->has('unknownFeature'));
     }
 
     /**
      * Test new feature
      */
-    public function testFeatureUnknownedVoter(): void
+    public function testFeatureUnknownVoter(): void
     {
         $this->expectException(VoterNotFoundException::class);
         $this->expectExceptionMessage('No voter with this alias: "testVoter" is registered');
 
         // Define a feature
         $features = [
-            'testfeature' => [
+            'testFeature' => [
                 'voter' => 'testVoter',
                 'params' => []
             ]
@@ -94,7 +94,7 @@ class FeatureServiceTest extends TestCase
         // Create service
         $service = new FeatureService($features, $default, $this->getRegistry());
 
-        $service->has('testfeature');
+        $service->has('testFeature');
     }
 
     /**

--- a/Tests/Twig/FeatureToggleExtensionTest.php
+++ b/Tests/Twig/FeatureToggleExtensionTest.php
@@ -27,8 +27,8 @@ class FeatureToggleExtensionTest extends TestCase
     {
         // Define response map for service stub
         $map = [
-            ['testfeature', true],
-            ['unknownfeature', false]
+            ['testFeature', true],
+            ['unknownFeature', false]
         ];
 
         /** @var MockObject&FeatureService $service */
@@ -46,7 +46,8 @@ class FeatureToggleExtensionTest extends TestCase
         $functions = $extension->getFunctions();
 
         // Check if functions are returned as array
-        $this->assertIsArray($functions);
+        // removed because TokenParser is always returned in an array
+        # $this->assertIsArray($functions);
 
         // Check if the function is a twig function
         $this->assertInstanceOf(TwigFunction::class, $functions[0]);
@@ -54,10 +55,10 @@ class FeatureToggleExtensionTest extends TestCase
         $callable = $functions[0]->getCallable();
 
         // Check if callable returns true for a known feature
-        $this->assertTrue($callable('testfeature'));
+        $this->assertTrue($callable('testFeature'));
 
         // Check if callable returns false for an unknown feature
-        $this->assertFalse($callable('unknownfeature'));
+        $this->assertFalse($callable('unknownFeature'));
 
     }
 }

--- a/Tests/Twig/FeatureToggleNodeTest.php
+++ b/Tests/Twig/FeatureToggleNodeTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Ecn\FeatureToggleBundle\Tests\Twig;
 
 use Ecn\FeatureToggleBundle\Twig\FeatureToggleNode;
+use Twig\Environment;
 use Twig\Node\Expression\NameExpression;
 use Twig\Node\Node;
 use Twig\Node\PrintNode;
@@ -25,15 +26,17 @@ class FeatureToggleNodeTest extends NodeTestCase
 {
     /**
      * @dataProvider getTests
+     *
+     * @param FeatureToggleNode $node
+     * @param string $source
+     * @param Environment $environment
+     * @param bool $isPattern
      */
     public function testCompile($node, $source, $environment = null, $isPattern = false)
     {
         parent::testCompile($node, $source, $environment = null, $isPattern = false);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function getTests(): array
     {
         $tests = [];

--- a/Tests/Twig/IntegrationTest.php
+++ b/Tests/Twig/IntegrationTest.php
@@ -9,9 +9,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Ecn\FeatureToggleBundle\Twig;
+namespace Ecn\FeatureToggleBundle\Tests\Twig;
 
 use Ecn\FeatureToggleBundle\Service\FeatureService;
+use Ecn\FeatureToggleBundle\Twig\FeatureToggleExtension;
 use Ecn\FeatureToggleBundle\Voters\AlwaysTrueVoter;
 use Ecn\FeatureToggleBundle\Voters\VoterRegistry;
 use Twig\Test\IntegrationTestCase;
@@ -28,6 +29,14 @@ class IntegrationTest extends IntegrationTestCase
 
     /**
      * @dataProvider getTests
+     *
+     * @param string $file
+     * @param string $message
+     * @param string $condition
+     * @param array $templates
+     * @param bool $exception
+     * @param array $outputs
+     * @param string $deprecation
      */
     public function testIntegration($file, $message, $condition, $templates, $exception, $outputs, $deprecation = ''): void
     {
@@ -37,6 +46,14 @@ class IntegrationTest extends IntegrationTestCase
     /**
      * @dataProvider getLegacyTests
      * @group legacy
+     *
+     * @param string $file
+     * @param string $message
+     * @param string $condition
+     * @param array $templates
+     * @param bool $exception
+     * @param array $outputs
+     * @param string $deprecation
      */
     public function testLegacyIntegration($file, $message, $condition, $templates, $exception, $outputs, $deprecation = ''): void
     {

--- a/Tests/Voters/RatioVoterTest.php
+++ b/Tests/Voters/RatioVoterTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  */
 class RatioVoterTest extends TestCase
 {
-    public $stickyValues = [];
+    public array $stickyValues = [];
 
     public function testLowRatioVoterPass(): void
     {
@@ -98,7 +98,7 @@ class RatioVoterTest extends TestCase
     {
         $voter = $this->getRatioVoter(0.5, true);
         $initialPass = $voter->pass();
-        $this->stickyValues = ['_ecn_featuretoggle_ratiotest' => $initialPass];
+        $this->stickyValues = ['_ecn_featuretoggle_ratioTest' => $initialPass];
 
         if ($initialPass) {
             $requiredHits = $this->executeTestIteration($voter) === 100;
@@ -112,28 +112,28 @@ class RatioVoterTest extends TestCase
     /**
      * Callback for session stub
      *
-     * @param $key
+     * @param string $key
      *
      * @return bool
      */
-    public function hasStickyCallback($key): bool
+    public function hasStickyCallback(string $key): bool
     {
-        return array_key_exists($key, $this->stickyValues);
+        return isset($this->stickyValues[$key]);
     }
 
     /**
      * Callback for session stub
      *
-     * @param $key
+     * @param string $key
      *
-     * @return mixed|null
+     * @return bool|null
      */
-    public function getStickyCallback($key)
+    public function getStickyCallback(string $key): bool|null
     {
         return $this->stickyValues[$key] ?? null;
     }
 
-    protected function getRatioVoter($ratio, $sticky = false, $hasSession = true): RatioVoter
+    protected function getRatioVoter(float $ratio, bool $sticky = false, bool $hasSession = true): RatioVoter
     {
         $session = null;
 
@@ -150,23 +150,23 @@ class RatioVoterTest extends TestCase
         $params = ['ratio' => $ratio, 'sticky' => $sticky];
 
         $voter = new RatioVoter($session);
-        $voter->setFeature('ratiotest');
+        $voter->setFeature('ratioTest');
         $voter->setParams($params);
 
         return $voter;
     }
 
     /**
-     * Executes the tests n time returning the number of passes
+     * Executes the Tests n time returning the number of passes
      *
      * @param RatioVoter $ratioVoter
-     * @param int $iterationCount
      *
      * @return int
      */
-    private function executeTestIteration(RatioVoter $ratioVoter, $iterationCount = 100): int
+    private function executeTestIteration(RatioVoter $ratioVoter): int
     {
         $hits = 0;
+        $iterationCount = 100;
 
         for ($i = 1; $i <= $iterationCount; $i++) {
             if ($ratioVoter->pass()) {

--- a/Tests/Voters/RequestHeaderVoterTest.php
+++ b/Tests/Voters/RequestHeaderVoterTest.php
@@ -34,12 +34,12 @@ class RequestHeaderVoterTest extends TestCase
 
     public function testNoCurrentRequestInRequestStack(): void
     {
-        $voter = $this->getRequestHeaderVoter(new RequestStack(), null);
+        $voter = $this->getRequestHeaderVoter(new RequestStack(), []);
 
         $this->assertFalse($voter->pass());
     }
 
-    private function getRequestHeaderVoter(RequestStack $requestStack, $requestHeaders = null): RequestHeaderVoter
+    private function getRequestHeaderVoter(RequestStack $requestStack, array $requestHeaders = []): RequestHeaderVoter
     {
         $voter = new RequestHeaderVoter();
         $voter->setRequest($requestStack);
@@ -50,14 +50,14 @@ class RequestHeaderVoterTest extends TestCase
 
     public function testNoRequestHeadersProvided(): void
     {
-        $voter = $this->getRequestHeaderVoter($this->getFakeRequestStack(), null);
+        $voter = $this->getRequestHeaderVoter($this->getFakeRequestStack(), []);
 
         $this->assertFalse($voter->pass());
     }
 
-    private function getFakeRequestStack($headers = []): RequestStack
+    private function getFakeRequestStack(array $headers = []): RequestStack
     {
-        $fakeRequest = Request::create('/', 'GET');
+        $fakeRequest = Request::create('/');
         $fakeRequest->headers->add($headers);
 
         $requestStack = new RequestStack();

--- a/Tests/Voters/ScheduleVoterTest.php
+++ b/Tests/Voters/ScheduleVoterTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Ecn\FeatureToggleBundle\Tests\Voters;
 
 use DateTime;
+use DateTimeInterface;
 use Ecn\FeatureToggleBundle\Voters\ScheduleVoter;
 use PHPUnit\Framework\TestCase;
 
@@ -23,12 +24,12 @@ class ScheduleVoterTest extends TestCase
 {
     public function testNoScheduleIsSet(): void
     {
-        $voter = $this->getScheduleVoter(null);
+        $voter = $this->getScheduleVoter('');
 
         $this->assertTrue($voter->pass());
     }
 
-    protected function getScheduleVoter($schedule): ScheduleVoter
+    protected function getScheduleVoter(string $schedule): ScheduleVoter
     {
         $voter = new ScheduleVoter();
         $voter->setParams(['schedule' => $schedule]);
@@ -45,14 +46,14 @@ class ScheduleVoterTest extends TestCase
 
     public function testEarlierScheduleIsSet(): void
     {
-        $voter = $this->getScheduleVoter((new DateTime())->modify('-1 second')->format(DateTime::RSS));
+        $voter = $this->getScheduleVoter((new DateTime())->modify('-1 second')->format(DateTimeInterface::RSS));
 
         $this->assertTrue($voter->pass());
     }
 
     public function testLaterScheduleIsSet(): void
     {
-        $voter = $this->getScheduleVoter((new DateTime())->modify('+1 second')->format(DateTime::RSS));
+        $voter = $this->getScheduleVoter((new DateTime())->modify('+1 second')->format(DateTimeInterface::RSS));
 
         $this->assertFalse($voter->pass());
     }

--- a/Tests/Voters/VoterRegistryTest.php
+++ b/Tests/Voters/VoterRegistryTest.php
@@ -49,6 +49,7 @@ class VoterRegistryTest extends TestCase
         $registry = new VoterRegistry();
         $registry->addVoter($voterOne, 'myFirstTestVoter');
 
-        $unknownVoter = $registry->getVoter('unknownVoter');
+        // unknownVoter should throw VoterNotFoundException
+        $registry->getVoter('unknownVoter');
     }
 }

--- a/Twig/FeatureToggleExtension.php
+++ b/Twig/FeatureToggleExtension.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * This file is part of the ECNFeatureToggle package.
@@ -12,6 +13,7 @@
 namespace Ecn\FeatureToggleBundle\Twig;
 
 use Ecn\FeatureToggleBundle\Service\FeatureService;
+use JetBrains\PhpStorm\Pure;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -25,7 +27,7 @@ class FeatureToggleExtension extends AbstractExtension
     /**
      * @var FeatureService
      */
-    protected $featureService;
+    protected FeatureService $featureService;
 
     /**
      * @param FeatureService $featureService
@@ -54,9 +56,9 @@ class FeatureToggleExtension extends AbstractExtension
     }
 
     /**
-     * @return FeatureToggleTokenParser[]
+     * @return array<FeatureToggleTokenParser> []
      */
-    public function getTokenParsers(): array
+    #[Pure] public function getTokenParsers(): array
     {
         return [
             new FeatureToggleTokenParser(),

--- a/Voters/RatioVoter.php
+++ b/Voters/RatioVoter.php
@@ -22,20 +22,9 @@ class RatioVoter implements VoterInterface
 {
     use VoterTrait;
 
-    /**
-     * @var SessionInterface|null
-     */
-    protected $session;
-
-    /**
-     * @var float
-     */
-    protected $ratio = 0.5;
-
-    /**
-     * @var bool
-     */
-    protected $sticky = false;
+    protected ?SessionInterface $session;
+    protected float $ratio = 0.5;
+    protected bool $sticky = false;
 
     /**
      * @param SessionInterface|null $session
@@ -50,8 +39,8 @@ class RatioVoter implements VoterInterface
      */
     public function setParams(array $params): void
     {
-        $this->ratio = array_key_exists('ratio', $params) ? $params['ratio'] : 0.5;
-        $this->sticky = array_key_exists('sticky', $params) ? $params['sticky'] : false;
+        $this->ratio = $params['ratio'] ?? 0.5;
+        $this->sticky = $params['sticky'] ?? false;
     }
 
     /**
@@ -76,7 +65,7 @@ class RatioVoter implements VoterInterface
     protected function getStickyRatioPass(): bool
     {
         if (null === $this->session) {
-            throw new InvalidArgumentException(sprintf('The service "%s" has a dependency on the session', get_class($this)));
+            throw new InvalidArgumentException(sprintf('The service "%s" has a dependency on the session', $this::class));
         }
 
         $sessionKey = '_ecn_featuretoggle_'.$this->feature;

--- a/Voters/RequestHeaderVoter.php
+++ b/Voters/RequestHeaderVoter.php
@@ -22,29 +22,18 @@ final class RequestHeaderVoter implements VoterInterface
 {
     use VoterTrait;
 
-    /**
-     * @var array
-     */
-    private $headers = [];
-
-    /**
-     * @var Request|null
-     */
-    private $request;
-
-    /**
-     * @var bool
-     */
-    private $checkHeaderValues = false;
+    private array $headers = [];
+    private ?Request $request = null;
+    private bool $checkHeaderValues = false;
 
     /**
      * {@inheritdoc}
      */
     public function setParams(array $params): void
     {
-        $headers = array_key_exists('headers', $params) ? $params['headers'] : null;
+        $headers = $params['headers'] ?? null;
 
-        $this->checkHeaderValues = $headers ? static::isAssociativeArray($headers) : false;
+        $this->checkHeaderValues = $headers && RequestHeaderVoter::isAssociativeArray($headers);
         $this->headers           = $headers;
     }
 

--- a/Voters/ScheduleVoter.php
+++ b/Voters/ScheduleVoter.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
 
 namespace Ecn\FeatureToggleBundle\Voters;
 
+use DateTime;
+use Exception;
+
 /**
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  */
@@ -21,17 +24,15 @@ final class ScheduleVoter implements VoterInterface
 
     /**
      * A valid DateTime representation
-     *
-     * @var string|null
      */
-    private $schedule;
+    private string $schedule = '';
 
     /**
      * {@inheritdoc}
      */
     public function setParams(array $params): void
     {
-        $this->schedule = array_key_exists('schedule', $params) ? $params['schedule'] : null;
+        $this->schedule = $params['schedule'] ?? '';
     }
 
     /**
@@ -40,16 +41,16 @@ final class ScheduleVoter implements VoterInterface
     public function pass(): bool
     {
         // Don't pass if schedule is invalid
-        if (null === $this->schedule) {
+        if ('' === $this->schedule) {
             return true;
         }
 
         try {
-            $schedule = new \DateTime($this->schedule);
-        } catch (\Throwable $e) {
+            $schedule = new DateTime($this->schedule);
+        } catch (Exception) {
             return false;
         }
 
-        return new \DateTime() >= $schedule;
+        return new DateTime() >= $schedule;
     }
 }

--- a/Voters/VoterInterface.php
+++ b/Voters/VoterInterface.php
@@ -21,7 +21,6 @@ interface VoterInterface
      * Add additional parameters from the feature definition
      *
      * @param array $params
-     *
      */
     public function setParams(array $params): void;
 

--- a/Voters/VoterRegistry.php
+++ b/Voters/VoterRegistry.php
@@ -22,7 +22,7 @@ class VoterRegistry
     /**
      * @var array<string, VoterInterface>
      */
-    private $voters = [];
+    private array $voters = [];
 
     /**
      * @param VoterInterface $voter The voter service to add
@@ -44,7 +44,7 @@ class VoterRegistry
      */
     public function getVoter(string $alias): VoterInterface
     {
-        if (array_key_exists($alias, $this->voters)) {
+        if (isset($this->voters[$alias])) {
             return $this->voters[$alias];
         }
 

--- a/Voters/VoterTrait.php
+++ b/Voters/VoterTrait.php
@@ -19,10 +19,7 @@ namespace Ecn\FeatureToggleBundle\Voters;
  */
 trait VoterTrait
 {
-    /**
-     * @var string
-     */
-    private $feature = "";
+    private string $feature = "";
 
     /**
      * {@inheritdoc}

--- a/composer.json
+++ b/composer.json
@@ -10,19 +10,22 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "symfony/framework-bundle": "~3.4.31|~4.2.7|^4.3.4",
-        "doctrine/annotations": "~1.6",
-        "doctrine/common": "2.10.0"
+        "php": "~8.0 | ~8.1",
+        "symfony/framework-bundle": "^5.4 | ^6.0",
+        "doctrine/common": "3.2.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.2|^7.5",
-        "squizlabs/php_codesniffer": "^3.3",
-        "escapestudios/symfony2-coding-standard": "^3.4.1",
-        "vimeo/psalm": "~3.4"
+        "phpunit/phpunit": "^9.5",
+        "squizlabs/php_codesniffer": "^3.6",
+        "escapestudios/symfony2-coding-standard": "^3.12",
+        "vimeo/psalm": "~4.21",
+        "jetbrains/phpstorm-attributes": "^1.0"
     },
     "conflict": {
         "phpunit/phpunit": "<5.4.3"
+    },
+    "suggest": {
+        "twig/twig": "^3.3"
     },
     "autoload": {
         "psr-4": {
@@ -39,10 +42,15 @@
         "psalm-no-twig": "vendor/bin/psalm --config=psalm.without_twig.xml",
         "test-ci": "vendor/bin/phpunit --coverage-text --coverage-clover build/coverage.xml"
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "extra": {
         "branch-alias": {
             "dev-master": "2.0-dev"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false"
+>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
-
+    <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./Resources</directory>
+      <directory>./Tests</directory>
+      <directory>./vendor</directory>
+    </exclude>
+  </coverage>
     <testsuites>
         <testsuite name="all">
             <directory>./Tests</directory>
@@ -11,15 +24,4 @@
             <exclude>./Tests/Twig</exclude>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Resources</directory>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/psalm.without_twig.xml
+++ b/psalm.without_twig.xml
@@ -2,7 +2,6 @@
 <psalm
     name="EcnFeatureToggleBundle"
     useDocblockTypes="true"
-    totallyTyped="false"
 >
     <projectFiles>
         <directory name="./" />
@@ -23,7 +22,6 @@
         <MissingReturnType errorLevel="info" />
         <MissingPropertyType errorLevel="info" />
         <InvalidDocblock errorLevel="info" />
-        <MisplacedRequiredParam errorLevel="info" />
 
         <PropertyNotSetInConstructor errorLevel="info" />
         <MissingConstructor errorLevel="info" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -2,7 +2,6 @@
 <psalm
     name="EcnFeatureToggleBundle"
     useDocblockTypes="true"
-    totallyTyped="false"
 >
     <projectFiles>
         <directory name="./" />
@@ -22,7 +21,6 @@
         <MissingReturnType errorLevel="info" />
         <MissingPropertyType errorLevel="info" />
         <InvalidDocblock errorLevel="info" />
-        <MisplacedRequiredParam errorLevel="info" />
 
         <PropertyNotSetInConstructor errorLevel="info" />
         <MissingConstructor errorLevel="info" />


### PR DESCRIPTION
Added:
- added support for PHP 8 and 8.1
- added support for Symfony 5.4 and 6
- added use of attributes

Changed:
- teardown in ControllerListenerTest [More setup than teardown](https://phpunit.readthedocs.io/en/9.5/fixtures.html#more-setup-than-teardown)

Removed:
- removed support for PHP 7
- removed support for Symfony 3 and 4
- removed annotations